### PR TITLE
fix nfs-kernel issue not resolving dns at reboot

### DIFF
--- a/hosts/host_vars/satan.yml
+++ b/hosts/host_vars/satan.yml
@@ -1,5 +1,7 @@
 ---
 
+sabnzbd_user_home: "/opt/sabnzbd"
+
 # nfs_server
 nfs_exports:
   - "{{ sabnzbd_user_home }} lucifer.local(rw,sync,no_root_squash,no_subtree_check)"

--- a/molecule/nfs_server/tests/test_nfs_server.py
+++ b/molecule/nfs_server/tests/test_nfs_server.py
@@ -20,3 +20,11 @@ def test_nfs_kernel_server_is_running(host):
 ])
 def test_nfs_exports(host, export):
     assert host.file("/etc/exports").contains(export)
+
+
+@pytest.mark.parametrize("line", [
+    "After=network-online.target",
+    "Wants=network-online.target"
+])
+def test_nfs_service_file(host, line):
+    assert host.file("/lib/systemd/system/nfs-kernel-server.service").contains(line)

--- a/roles/nfs_server/handlers/main.yml
+++ b/roles/nfs_server/handlers/main.yml
@@ -5,4 +5,5 @@
   service:
     name: nfs-kernel-server
     state: restarted
+    daemon_reload: true
     enabled: yes

--- a/roles/nfs_server/tasks/configure.yml
+++ b/roles/nfs_server/tasks/configure.yml
@@ -1,0 +1,15 @@
+---
+
+- name: add After and Wants to service file to wait until network is online
+  become: yes
+  lineinfile:
+    path: "/lib/systemd/system/nfs-kernel-server.service"
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+    insertafter: "^After=nfs-config.service$"
+    state: present
+  loop:
+    - { regexp: "After=network-online.target", line: "After=network-online.target" }
+    - { regexp: "Wants=network-online.target", line: "Wants=network-online.target" }
+  notify:
+    - restart nfs

--- a/roles/nfs_server/tasks/main.yml
+++ b/roles/nfs_server/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
 
 - include_tasks: install.yml
+- include_tasks: configure.yml
 - include_tasks: nfs_exports.yml


### PR DESCRIPTION
when /etx/exports contains a dns name we need to have networking available so we can resolve it.